### PR TITLE
alias :srcディレクトリパスを追加

### DIFF
--- a/components/Layout.jsx
+++ b/components/Layout.jsx
@@ -1,6 +1,6 @@
 import Head from 'next/head'
-import styles from './layout.module.css'
-import utilStyles from '../src/styles/utils.module.css'
+import styles from '@components/layout.module.css'
+import utilStyles from '@/styles/utils.module.css'
 import Link from 'next/link'
 import Image from 'next/image'
 

--- a/lib/post.tsx
+++ b/lib/post.tsx
@@ -1,5 +1,5 @@
-import { client } from '@/../lib/microCMS'
-import type { Blog } from '@/../types/microCMS'
+import { client } from '@lib/microCMS'
+import type { Blog } from '~types/microCMS'
 
 //ブログ一覧取得
 export const getBlogs = async (): Promise<Blog[]> => {

--- a/lib/post.tsx
+++ b/lib/post.tsx
@@ -1,5 +1,5 @@
-import { client } from '@lib/microCMS'
-import type { Blog } from '~types/microCMS'
+import { client } from '@/lib/microCMS'
+import type { Blog } from '@/types/microCMS'
 
 //ブログ一覧取得
 export const getBlogs = async (): Promise<Blog[]> => {

--- a/lib/post.tsx
+++ b/lib/post.tsx
@@ -1,5 +1,5 @@
-import { client } from '../lib/microCMS'
-import type { Blog } from '../types/microCMS'
+import { client } from '@/../lib/microCMS'
+import type { Blog } from '@/../types/microCMS'
 
 //ブログ一覧取得
 export const getBlogs = async (): Promise<Blog[]> => {

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,17 @@
 /** @type {import('next').NextConfig} */
+const path = require('path')
+
+/** Next.jsの設定値 */
 const nextConfig = {
   reactStrictMode: true,
+  /** WebPack の設定を追加 */
+  webpack: (config) => {
+    // Vue と同じように 「@ = src/」,「~ = src/」に設定する。
+    // => モジュールのパス解決とエイリアスを設定している。
+    config.resolve.alias['@'] = path.resolve(__dirname, 'src')
+    config.resolve.alias['~'] = path.join(__dirname, 'src')
+    return config
+  },
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,12 @@ const nextConfig = {
     // => モジュールのパス解決とエイリアスを設定している。
     config.resolve.alias['@'] = path.resolve(__dirname, 'src')
     config.resolve.alias['~'] = path.join(__dirname, 'src')
+    config.resolve.alias['@lib'] = path.resolve(__dirname, 'lib')
+    config.resolve.alias['~lib'] = path.join(__dirname, 'lib')
+    config.resolve.alias['@types'] = path.resolve(__dirname, 'types')
+    config.resolve.alias['~types'] = path.join(__dirname, 'types')
+    config.resolve.alias['@components'] = path.resolve(__dirname, 'components')
+    config.resolve.alias['~components'] = path.join(__dirname, 'components')
     return config
   },
 }

--- a/next.config.js
+++ b/next.config.js
@@ -10,11 +10,11 @@ const nextConfig = {
     // => モジュールのパス解決とエイリアスを設定している。
     config.resolve.alias['@'] = path.resolve(__dirname, 'src')
     config.resolve.alias['~'] = path.join(__dirname, 'src')
-    config.resolve.alias['@lib'] = path.resolve(__dirname, 'lib')
+    config.resolve.alias['@/lib'] = path.resolve(__dirname, 'lib')
     config.resolve.alias['~lib'] = path.join(__dirname, 'lib')
-    config.resolve.alias['@types'] = path.resolve(__dirname, 'types')
+    config.resolve.alias['@/types'] = path.resolve(__dirname, 'types')
     config.resolve.alias['~types'] = path.join(__dirname, 'types')
-    config.resolve.alias['@components'] = path.resolve(__dirname, 'components')
+    config.resolve.alias['@/components'] = path.resolve(__dirname, 'components')
     config.resolve.alias['~components'] = path.join(__dirname, 'components')
     return config
   },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,11 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import Head from 'next/head'
-import Layout, { siteTitle } from '../../components/Layout'
-import { getBlogs } from '../../lib/post'
-import utilStyle from '../styles/utils.module.css'
-import styles from '../styles/home.module.css'
-import type { Blog } from '../../types/microCMS'
+import Layout, { siteTitle } from '@/../components/Layout'
+import { getBlogs } from '@/../lib/post'
+import utilStyle from '@/styles/utils.module.css'
+import styles from '@/styles/home.module.css'
+import type { Blog } from '@/../types/microCMS'
 
 //SSGの場合
 export async function getStaticProps() {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,11 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import Head from 'next/head'
-import Layout, { siteTitle } from '@components/Layout'
-import { getBlogs } from '@lib/post'
+import Layout, { siteTitle } from '@/components/Layout'
+import { getBlogs } from '@/lib/post'
 import utilStyle from '@/styles/utils.module.css'
 import styles from '@/styles/home.module.css'
-import type { Blog } from '~types/microCMS'
+import type { Blog } from '@/types/microCMS'
 
 //SSGの場合
 export async function getStaticProps() {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,11 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import Head from 'next/head'
-import Layout, { siteTitle } from '@/../components/Layout'
-import { getBlogs } from '@/../lib/post'
+import Layout, { siteTitle } from '@components/Layout'
+import { getBlogs } from '@lib/post'
 import utilStyle from '@/styles/utils.module.css'
 import styles from '@/styles/home.module.css'
-import type { Blog } from '@/../types/microCMS'
+import type { Blog } from '~types/microCMS'
 
 //SSGの場合
 export async function getStaticProps() {

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -1,8 +1,8 @@
 import Head from 'next/head'
-import Layout from '@/../components/Layout'
-import { getBlogIds, getBlogById } from '@/../lib/post'
+import Layout from '@components/Layout'
+import { getBlogIds, getBlogById } from '@lib/post'
 import utilStyles from '@/styles/utils.module.css'
-import type { Blog } from '@/../../types/microCMS'
+import type { Blog } from '~types/microCMS'
 import Image from 'next/image'
 
 //URLの動的に変わる部分のパスを返す

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -1,8 +1,8 @@
 import Head from 'next/head'
-import Layout from '../../../components/Layout'
-import { getBlogIds, getBlogById } from '../../../lib/post'
-import utilStyles from '../../styles/utils.module.css'
-import type { Blog } from '../../../types/microCMS'
+import Layout from '@/../components/Layout'
+import { getBlogIds, getBlogById } from '@/../lib/post'
+import utilStyles from '@/styles/utils.module.css'
+import type { Blog } from '@/../../types/microCMS'
 import Image from 'next/image'
 
 //URLの動的に変わる部分のパスを返す

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -1,8 +1,8 @@
 import Head from 'next/head'
-import Layout from '@components/Layout'
-import { getBlogIds, getBlogById } from '@lib/post'
+import Layout from '@/components/Layout'
+import { getBlogIds, getBlogById } from '@/lib/post'
 import utilStyles from '@/styles/utils.module.css'
-import type { Blog } from '~types/microCMS'
+import type { Blog } from '@/types/microCMS'
 import Image from 'next/image'
 
 //URLの動的に変わる部分のパスを返す

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,11 +16,11 @@
     "paths": {
       "@/*": ["./src/*"],
       "~/*": ["./src/*"],
-      "@types/*": ["./types/*"],
+      "@/types/*": ["./types/*"],
       "~types/*": ["./types/*"],
-      "@lib/*": ["./lib/*"],
+      "@/lib/*": ["./lib/*"],
       "~lib/*": ["./lib/*"],
-      "@components/*": ["./components/*"],
+      "@/components/*": ["./components/*"],
       "~components/*": ["./components/*"]
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,13 @@
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"],
-      "~/*": ["./src/*"]
+      "~/*": ["./src/*"],
+      "@types/*": ["./types/*"],
+      "~types/*": ["./types/*"],
+      "@lib/*": ["./lib/*"],
+      "~lib/*": ["./lib/*"],
+      "@components/*": ["./components/*"],
+      "~components/*": ["./components/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,12 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"],
+      "~/*": ["./src/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
・aliasの設定を追加

【next.config.js】
    config.resolve.alias['@'] = path.resolve(__dirname, 'src')
    config.resolve.alias['~'] = path.join(__dirname, 'src')

【tsconfig.json】
　compilerOptionsに追加
    "baseUrl": "./",
    "paths": {
      "@/*": ["./src/*"],
      "~/*": ["./src/*"]

・aliasの変更に伴いimport文のパスを@に変更
　対象のファイル：post.tsx, [id].tsx, index.tsx 